### PR TITLE
Disable Miri for tests that rely on system calls

### DIFF
--- a/src/hash_table/bucket.rs
+++ b/src/hash_table/bucket.rs
@@ -956,6 +956,7 @@ mod test {
     use tokio::sync;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+    #[cfg_attr(miri, ignore)]
     async fn queue() {
         let num_tasks = BUCKET_LEN + 2;
         let barrier = Arc::new(sync::Barrier::new(num_tasks));

--- a/src/tests/correctness.rs
+++ b/src/tests/correctness.rs
@@ -951,7 +951,7 @@ mod treeindex_test {
             tokio::task::yield_now().await;
         }
     }
-    
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
     #[cfg_attr(miri, ignore)]
     async fn integer_key() {

--- a/src/tests/correctness.rs
+++ b/src/tests/correctness.rs
@@ -74,6 +74,7 @@ mod hashmap_test {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn insert_drop() {
         static INST_CNT: AtomicUsize = AtomicUsize::new(0);
         let hashmap: HashMap<usize, R> = HashMap::default();
@@ -93,6 +94,7 @@ mod hashmap_test {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn clear() {
         static INST_CNT: AtomicUsize = AtomicUsize::new(0);
         let hashmap: HashMap<usize, R> = HashMap::default();
@@ -115,6 +117,7 @@ mod hashmap_test {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn clone() {
         static INST_CNT: AtomicUsize = AtomicUsize::new(0);
         let hashmap: HashMap<usize, R> = HashMap::default();
@@ -195,6 +198,7 @@ mod hashmap_test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+    #[cfg_attr(miri, ignore)]
     async fn integer_key() {
         let hashmap: Arc<HashMap<usize, usize>> = Arc::new(HashMap::default());
 
@@ -290,6 +294,7 @@ mod hashmap_test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[cfg_attr(miri, ignore)]
     async fn retain_for_each() {
         let hashmap: Arc<HashMap<usize, usize>> = Arc::new(HashMap::default());
 
@@ -435,6 +440,7 @@ mod hashmap_test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[cfg_attr(miri, ignore)]
     async fn read() {
         let hashmap: Arc<HashMap<usize, usize>> = Arc::new(HashMap::default());
         let num_tasks = 4;
@@ -587,6 +593,7 @@ mod hashindex_test {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn clear() {
         static INST_CNT: AtomicUsize = AtomicUsize::new(0);
         let hashindex: HashIndex<usize, R> = HashIndex::default();
@@ -610,6 +617,7 @@ mod hashindex_test {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn clone() {
         static INST_CNT: AtomicUsize = AtomicUsize::new(0);
         let hashindex: HashIndex<usize, R> = HashIndex::default();
@@ -666,6 +674,7 @@ mod hashindex_test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[cfg_attr(miri, ignore)]
     async fn read() {
         let hashindex: Arc<HashIndex<usize, usize>> = Arc::new(HashIndex::default());
         let num_tasks = 4;
@@ -703,6 +712,7 @@ mod hashindex_test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[cfg_attr(miri, ignore)]
     async fn rebuild() {
         let hashindex: Arc<HashIndex<usize, usize>> = Arc::new(HashIndex::default());
         let num_tasks = 4;
@@ -857,6 +867,7 @@ mod treeindex_test {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn insert_drop() {
         static INST_CNT: AtomicUsize = AtomicUsize::new(0);
         let tree: TreeIndex<usize, R> = TreeIndex::default();
@@ -876,6 +887,7 @@ mod treeindex_test {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn insert_remove() {
         static INST_CNT: AtomicUsize = AtomicUsize::new(0);
         let tree: TreeIndex<usize, R> = TreeIndex::default();
@@ -898,6 +910,7 @@ mod treeindex_test {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn clear() {
         static INST_CNT: AtomicUsize = AtomicUsize::new(0);
         let tree: TreeIndex<usize, R> = TreeIndex::default();
@@ -917,6 +930,7 @@ mod treeindex_test {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn clone() {
         static INST_CNT: AtomicUsize = AtomicUsize::new(0);
         let tree: TreeIndex<usize, R> = TreeIndex::default();
@@ -937,8 +951,9 @@ mod treeindex_test {
             tokio::task::yield_now().await;
         }
     }
-
+    
     #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+    #[cfg_attr(miri, ignore)]
     async fn integer_key() {
         let num_tasks = 8;
         let workload_size = 256;
@@ -1402,6 +1417,7 @@ mod bag_test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+    #[cfg_attr(miri, ignore)]
     async fn mpmc() {
         static INST_CNT: AtomicUsize = AtomicUsize::new(0);
         const NUM_TASKS: usize = 6;
@@ -1477,6 +1493,7 @@ mod queue_test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+    #[cfg_attr(miri, ignore)]
     async fn mpmc() {
         const NUM_TASKS: usize = 12;
         const NUM_PRODUCERS: usize = NUM_TASKS / 2;
@@ -1561,6 +1578,7 @@ mod stack_test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+    #[cfg_attr(miri, ignore)]
     async fn mpmc() {
         const NUM_TASKS: usize = 12;
         let stack: Arc<Stack<R>> = Arc::new(Stack::default());
@@ -1843,6 +1861,7 @@ mod ebr_test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+    #[cfg_attr(miri, ignore)]
     async fn atomic_arc_parallel() {
         let atomic_arc: Arc<AtomicArc<String>> =
             Arc::new(AtomicArc::new(String::from("How are you?")));
@@ -1911,6 +1930,7 @@ mod ebr_test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+    #[cfg_attr(miri, ignore)]
     async fn atomic_arc_clone() {
         let atomic_arc: Arc<AtomicArc<String>> =
             Arc::new(AtomicArc::new(String::from("How are you?")));

--- a/src/tests/performance.rs
+++ b/src/tests/performance.rs
@@ -1416,7 +1416,7 @@ mod benchmark_async {
             assert_eq!(treeindex.len(), 0);
         }
     }
-
+    #[cfg_attr(miri, ignore)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 6)]
     async fn benchmarks_async() {
         hashmap_benchmark(65536, vec![1, 2, 4]).await;

--- a/src/tree_index/internal_node.rs
+++ b/src/tree_index/internal_node.rs
@@ -1048,6 +1048,7 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+    #[cfg_attr(miri, ignore)]
     async fn parallel() {
         let num_tasks = 8;
         let workload_size = 64;
@@ -1143,6 +1144,7 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+    #[cfg_attr(miri, ignore)]
     async fn durability() {
         let num_tasks = 16_usize;
         let num_iterations = 64;

--- a/src/tree_index/leaf.rs
+++ b/src/tree_index/leaf.rs
@@ -1117,6 +1117,7 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+    #[cfg_attr(miri, ignore)]
     async fn update() {
         let num_excess = 3;
         let num_tasks = DIMENSION.num_entries + num_excess;
@@ -1190,6 +1191,7 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+    #[cfg_attr(miri, ignore)]
     async fn durability() {
         let num_tasks = 16_usize;
         let workload_size = 8_usize;

--- a/src/tree_index/leaf_node.rs
+++ b/src/tree_index/leaf_node.rs
@@ -1098,6 +1098,7 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+    #[cfg_attr(miri, ignore)]
     async fn parallel() {
         let num_tasks = 8;
         let workload_size = 64;
@@ -1195,6 +1196,7 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+    #[cfg_attr(miri, ignore)]
     async fn durability() {
         let num_tasks = 16_usize;
         let workload_size = 64_usize;


### PR DESCRIPTION
Ignore unsupported test cases to help with #86 and related issues.