### PR TITLE
Use compare_exchange_weak in a few simple places

### DIFF
--- a/src/ebr/ref_counted.rs
+++ b/src/ebr/ref_counted.rs
@@ -87,13 +87,14 @@ impl<T> RefCounted<T> {
         debug_assert_ne!(current, 0);
         loop {
             let new = if current <= 1 { 0 } else { current - 2 };
-            if let Err(actual) = self
+            match self
                 .ref_cnt()
                 .compare_exchange_weak(current, new, Relaxed, Relaxed)
             {
-                current = actual;
-            } else {
-                break;
+                Ok(_) => break,
+                Err(actual) => {
+                    current = actual;
+                }
             }
         }
         current == 1

--- a/src/hash_table.rs
+++ b/src/hash_table.rs
@@ -50,12 +50,13 @@ where
     fn reserve_capacity(&self, additional_capacity: usize) -> usize {
         let mut current_minimum_capacity = self.minimum_capacity().load(Relaxed);
         loop {
-            if usize::MAX - current_minimum_capacity <= additional_capacity {
+            let Some(new_minimum_capacity) = current_minimum_capacity.checked_add(additional_capacity) else {
                 return 0;
-            }
-            match self.minimum_capacity().compare_exchange(
+            };
+
+            match self.minimum_capacity().compare_exchange_weak(
                 current_minimum_capacity,
-                current_minimum_capacity + additional_capacity,
+                new_minimum_capacity,
                 Relaxed,
                 Relaxed,
             ) {

--- a/src/wait_queue.rs
+++ b/src/wait_queue.rs
@@ -27,7 +27,7 @@ impl WaitQueue {
         let mut entry = SyncWait::new(current);
         let mut entry_mut = Pin::new(&mut entry);
 
-        while let Err(actual) = self.wait_queue.compare_exchange(
+        while let Err(actual) = self.wait_queue.compare_exchange_weak(
             current,
             entry_mut.as_mut().get_mut() as *mut SyncWait as usize,
             AcqRel,
@@ -63,7 +63,7 @@ impl WaitQueue {
         async_wait.next = current;
         async_wait.mutex.replace(Mutex::new((false, None)));
 
-        while let Err(actual) = self.wait_queue.compare_exchange(
+        while let Err(actual) = self.wait_queue.compare_exchange_weak(
             current,
             (async_wait as *mut AsyncWait as usize) | ASYNC,
             AcqRel,


### PR DESCRIPTION
On arm/aarch64 (and possibly other targets), `compare_exchange` (`_strong`) will effectively generate an additional check loop on top of `compare_exchange_weak` codegen. As spurious failures are relatively uncommon, we may as well combine those loops in code if they don't do too much work to setup the new value. 

On x86, the codegen should be exactly the same.