### PR TITLE
Implement Default for any BuildHasher

### DIFF
--- a/src/hash_index.rs
+++ b/src/hash_index.rs
@@ -899,7 +899,7 @@ where
     /// ```
     /// use scc::HashIndex;
     ///
-    /// let hashindex: HashIndex<u64, u32, _> = HashIndex::default();
+    /// let hashindex: HashIndex<u64, u32> = HashIndex::default();
     ///
     /// let result = hashindex.capacity();
     /// assert_eq!(result, 0);

--- a/src/hash_index.rs
+++ b/src/hash_index.rs
@@ -884,14 +884,15 @@ where
     }
 }
 
-impl<K, V> Default for HashIndex<K, V, RandomState>
+impl<K, V, H> Default for HashIndex<K, V, H>
 where
     K: 'static + Clone + Eq + Hash,
     V: 'static + Clone,
+    H: BuildHasher + Default,
 {
     /// Creates an empty default [`HashIndex`].
     ///
-    /// The default hash builder is [`RandomState`], and the default capacity is `64`.
+    /// The default capacity is `64`.
     ///
     /// # Examples
     ///
@@ -908,7 +909,7 @@ where
         HashIndex {
             array: AtomicArc::null(),
             minimum_capacity: AtomicUsize::new(0),
-            build_hasher: RandomState::new(),
+            build_hasher: Default::default(),
         }
     }
 }

--- a/src/hash_map.rs
+++ b/src/hash_map.rs
@@ -1449,9 +1449,10 @@ where
     }
 }
 
-impl<K, V> Default for HashMap<K, V, RandomState>
+impl<K, V, H> Default for HashMap<K, V, H>
 where
     K: Eq + Hash,
+    H: BuildHasher + Default,
 {
     /// Creates an empty default [`HashMap`].
     ///
@@ -1470,7 +1471,7 @@ where
         HashMap {
             array: AtomicArc::null(),
             minimum_capacity: AtomicUsize::new(0),
-            build_hasher: RandomState::new(),
+            build_hasher: Default::default(),
         }
     }
 }

--- a/src/hash_set.rs
+++ b/src/hash_set.rs
@@ -713,10 +713,14 @@ impl<K: Eq + Hash> HashSet<K, RandomState> {
     }
 }
 
-impl<K: Eq + Hash> Default for HashSet<K, RandomState> {
+impl<K, H> Default for HashSet<K, H>
+where
+    K: Eq + Hash,
+    H: BuildHasher + Default,
+{
     /// Creates an empty default [`HashSet`].
     ///
-    /// The default hash builder is [`RandomState`], and the default capacity is `64`.
+    /// The default capacity is `64`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Other hashmaps allow `Default` to be used regardless of hash builder, so long as it also provides a default value. 

This makes it possible to `#[derive(Default)]` on structs that use scc types with other hashers. 