### PR TITLE
fix(hash_cache, linked_list, #130): optimization and API update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 2
 
+2.1.0
+
+* API update: `Queue` and `Stack` entries no longer implement `LinkedList`.
+* Much faster `Queue` and `Stack` entry garbage collection.
+
 2.0.17
 
 * Faster `Queue` and `Stack` entry garbage collection.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "scc"
 description = "High performance containers and utilities for concurrent and asynchronous programming"
 documentation = "https://docs.rs/scc"
-version = "2.0.17"
+version = "2.1.0"
 authors = ["wvwwvwwv <wvwwvwwv@me.com>"]
 edition = "2021"
 rust-version = "1.65.0"

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ assert_eq!(entry_ref, (&1, &1));
 
 ## HashCache
 
-[HashCache](#HashCache) is a concurrent sampling-based LRU cache that is based on the [HashMap](#HashMap) implementation. [HashCache](#HashCache) does not keep track of the least recently used entry in the entire cache, instead each bucket maintains a doubly linked list of occupied entries which is updated on access to entries in order to keep track of the least recently used entry within the bucket.
+[HashCache](#HashCache) is a 32-way associative concurrent sampling-based LRU cache that is based on the [HashMap](#HashMap) implementation. [HashCache](#HashCache) does not keep track of the least recently used entry in the entire cache, instead each bucket maintains a doubly linked list of occupied entries which is updated on access to entries in order to keep track of the least recently used entry within the bucket.
 
 ### Examples
 

--- a/src/hash_cache.rs
+++ b/src/hash_cache.rs
@@ -18,11 +18,12 @@ use std::sync::atomic::Ordering::{Acquire, Relaxed};
 
 /// Scalable concurrent sampling-based LRU cache backed by [`HashMap`](super::HashMap).
 ///
-/// [`HashCache`] is a concurrent sampling-based LRU cache that is based on the
+/// [`HashCache`] is a concurrent 32-way associative sampling-based LRU cache that is based on the
 /// [`HashMap`](super::HashMap) implementation. [`HashCache`] does not keep track of the least
 /// recently used entry in the entire cache, instead each bucket maintains a doubly linked list of
 /// occupied entries which is updated on access to entries in order to keep track of the least
-/// recently used entry within the bucket.
+/// recently used entry within the bucket. Therefore, entries can be evicted before the cache is
+/// full.
 ///
 /// [`HashCache`] and [`HashMap`](super::HashMap) share the same runtime characteristic, except
 /// that each entry in a [`HashCache`] additionally uses 2-byte space for a doubly linked list, and

--- a/src/hash_table/bucket.rs
+++ b/src/hash_table/bucket.rs
@@ -1392,12 +1392,8 @@ mod test {
             task_handles.push(tokio::spawn(async move {
                 barrier_clone.wait().await;
                 let partial_hash = (task_id % BUCKET_LEN).try_into().unwrap();
-                let bucket_mut = unsafe {
-                    &mut *(bucket_clone.as_ptr() as *mut Bucket<usize, usize, (), SEQUENTIAL>)
-                };
-                let data_block_mut = unsafe {
-                    &mut *(data_block_clone.as_ptr() as *mut DataBlock<usize, usize, BUCKET_LEN>)
-                };
+                let bucket_mut = unsafe { &mut *bucket_clone.as_ptr().cast_mut() };
+                let data_block_mut = unsafe { &mut *data_block_clone.as_ptr().cast_mut() };
                 let guard = Guard::new();
                 for i in 0..2048 {
                     let mut exclusive_locker = Locker::lock(bucket_mut, &guard).unwrap();
@@ -1496,17 +1492,12 @@ mod test {
                         {
                             let guard = Guard::new();
                             if let Ok(exclusive_locker) = Locker::try_lock_or_wait(
-                                unsafe {
-                                    &mut *(bucket_clone.as_ptr()
-                                        as *mut Bucket<usize, usize, (), SEQUENTIAL>)
-                                },
+                                unsafe { &mut *bucket_clone.as_ptr().cast_mut() },
                                 async_wait_pinned.derive().unwrap(),
                                 &guard,
                             ) {
-                                let data_block_mut = unsafe {
-                                    &mut *(data_block_clone.as_ptr()
-                                        as *mut DataBlock<usize, usize, BUCKET_LEN>)
-                                };
+                                let data_block_mut =
+                                    unsafe { &mut *data_block_clone.as_ptr().cast_mut() };
                                 let mut exclusive_locker = exclusive_locker.unwrap();
                                 exclusive_locker.insert_with(
                                     data_block_mut,
@@ -1542,14 +1533,8 @@ mod test {
                         async_wait_pinned.await;
                     }
                     {
-                        let bucket_mut = unsafe {
-                            &mut *(bucket_clone.as_ptr()
-                                as *mut Bucket<usize, usize, (), SEQUENTIAL>)
-                        };
-                        let data_block_mut = unsafe {
-                            &mut *(data_block_clone.as_ptr()
-                                as *mut DataBlock<usize, usize, BUCKET_LEN>)
-                        };
+                        let bucket_mut = unsafe { &mut *bucket_clone.as_ptr().cast_mut() };
+                        let data_block_mut = unsafe { &mut *data_block_clone.as_ptr().cast_mut() };
                         let guard = Guard::new();
                         let mut exclusive_locker = Locker::lock(bucket_mut, &guard).unwrap();
                         let entry_ptr =

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -479,7 +479,7 @@ fn next<'g, T, F: Fn(&T) -> &AtomicShared<T>>(
     let current_state = current.load(order, guard);
     let mut entry_ptr = current_state;
     let mut cleanup_target_range = (Ptr::null(), Ptr::null());
-    let mut cleanup_range_ended = false;
+    let mut cleanup_range_ended = current_state.tag() == Tag::Both;
     let next_valid_ptr = loop {
         if let Some(entry) = entry_ptr.as_ref() {
             let entry_state = state_getter(entry).load(order, guard);
@@ -509,7 +509,7 @@ fn next<'g, T, F: Fn(&T) -> &AtomicShared<T>>(
     };
 
     // Update its link if an invalid entry was found.
-    if current_state != next_valid_ptr {
+    if current_state.tag() != Tag::Both && current_state != next_valid_ptr {
         let next_valid_entry = next_valid_ptr.get_shared();
         if next_valid_entry.is_none() == next_valid_ptr.is_null() {
             // Keep the tag value.

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -1,7 +1,7 @@
 use super::ebr::{AtomicShared, Guard, Ptr, Shared, Tag};
 use std::fmt::{self, Debug, Display};
 use std::ops::{Deref, DerefMut};
-use std::sync::atomic::Ordering::{self, Relaxed, Release};
+use std::sync::atomic::Ordering::{self, Acquire, Relaxed, Release};
 
 /// [`LinkedList`] is a type trait implementing a lock-free singly linked list.
 pub trait LinkedList: Sized {
@@ -37,7 +37,7 @@ pub trait LinkedList: Sized {
     /// ```
     #[inline]
     fn is_clear(&self, order: Ordering) -> bool {
-        self.link_ref().tag(order) == Tag::None
+        is_clear_entry(self.link_ref(), order)
     }
 
     /// Marks `self` with an internal flag to denote that `self` is in a special state.
@@ -64,11 +64,10 @@ pub trait LinkedList: Sized {
     /// ```
     #[inline]
     fn mark(&self, order: Ordering) -> bool {
-        self.link_ref()
-            .update_tag_if(Tag::First, |ptr| ptr.tag() == Tag::None, order, Relaxed)
+        mark_entry(self.link_ref(), order)
     }
 
-    /// Removes the mark from `self`.
+    /// Removes any mark from `self`.
     ///
     /// Returns `false` if no flag has been marked on `self`.
     ///
@@ -95,8 +94,7 @@ pub trait LinkedList: Sized {
     /// ```
     #[inline]
     fn unmark(&self, order: Ordering) -> bool {
-        self.link_ref()
-            .update_tag_if(Tag::None, |ptr| ptr.tag() == Tag::First, order, Relaxed)
+        unmark_entry(self.link_ref(), order)
     }
 
     /// Returns `true` if `self` has a mark on it.
@@ -123,7 +121,7 @@ pub trait LinkedList: Sized {
     /// ```
     #[inline]
     fn is_marked(&self, order: Ordering) -> bool {
-        self.link_ref().tag(order) == Tag::First
+        is_marked_entry(self.link_ref(), order)
     }
 
     /// Deletes `self`.
@@ -156,8 +154,7 @@ pub trait LinkedList: Sized {
     /// ```
     #[inline]
     fn delete_self(&self, order: Ordering) -> bool {
-        self.link_ref()
-            .update_tag_if(Tag::Second, |ptr| ptr.tag() != Tag::Second, order, Relaxed)
+        delete_entry(self.link_ref(), order)
     }
 
     /// Returns `true` if `self` has been deleted.
@@ -184,10 +181,10 @@ pub trait LinkedList: Sized {
     /// ```
     #[inline]
     fn is_deleted(&self, order: Ordering) -> bool {
-        self.link_ref().tag(order) == Tag::Second
+        is_deleted_entry(self.link_ref(), order)
     }
 
-    /// Appends the given entry after `self` and returns a pointer to the entry.
+    /// Appends the given entry to `self` and returns a pointer to the entry.
     ///
     /// If `mark` is given `true`, it atomically marks an internal flag on `self` when updating
     /// the linked list, otherwise it removes marks.
@@ -226,36 +223,12 @@ pub trait LinkedList: Sized {
     #[inline]
     fn push_back<'g>(
         &self,
-        mut entry: Shared<Self>,
+        entry: Shared<Self>,
         mark: bool,
         order: Ordering,
         guard: &'g Guard,
     ) -> Result<Ptr<'g, Self>, Shared<Self>> {
-        let new_tag = if mark { Tag::First } else { Tag::None };
-        let mut next_ptr = self.link_ref().load(Relaxed, guard);
-        while next_ptr.tag() != Tag::Second {
-            entry
-                .link_ref()
-                .swap((next_ptr.get_shared(), Tag::None), Relaxed);
-            match self.link_ref().compare_exchange_weak(
-                next_ptr,
-                (Some(entry), new_tag),
-                order,
-                Relaxed,
-                guard,
-            ) {
-                Ok((_, updated)) => {
-                    return Ok(updated);
-                }
-                Err((passed, actual)) => {
-                    entry = unsafe { passed.unwrap_unchecked() };
-                    next_ptr = actual;
-                }
-            }
-        }
-
-        // `self` has been deleted.
-        Err(entry)
+        push_back_entry(self.link_ref(), entry, mark, |l| l.link_ref(), order, guard)
     }
 
     /// Returns the closest next valid entry.
@@ -290,38 +263,7 @@ pub trait LinkedList: Sized {
     /// ```
     #[inline]
     fn next_ptr<'g>(&self, order: Ordering, guard: &'g Guard) -> Ptr<'g, Self> {
-        let self_next_ptr = self.link_ref().load(order, guard);
-        let self_tag = self_next_ptr.tag();
-        let mut next_ptr = self_next_ptr;
-        let mut update_self = false;
-        let next_valid_ptr = loop {
-            if let Some(next_ref) = next_ptr.as_ref() {
-                let next_next_ptr = next_ref.link_ref().load(order, guard);
-                if next_next_ptr.tag() != Tag::Second {
-                    break next_ptr;
-                }
-                update_self = true;
-                next_ptr = next_next_ptr;
-            } else {
-                break Ptr::null();
-            }
-        };
-
-        // Updates its link if an invalid entry has been found, and `self` is a valid one.
-        if update_self && self_tag != Tag::Second {
-            self.link_ref()
-                .compare_exchange(
-                    self_next_ptr,
-                    (next_valid_ptr.get_shared(), self_tag),
-                    Release,
-                    Relaxed,
-                    guard,
-                )
-                .ok()
-                .map(|(p, _)| p.map(|p| p.release(guard)));
-        }
-
-        next_valid_ptr
+        next_entry(self.link_ref(), &|l| l.link_ref(), 32, order, guard)
     }
 }
 
@@ -335,13 +277,27 @@ pub struct Entry<T> {
 }
 
 impl<T> Entry<T> {
-    /// Creates a new [`Entry`].
     #[inline]
     pub(super) fn new(val: T) -> Self {
         Self {
             instance: Some(val),
             next: AtomicShared::default(),
         }
+    }
+
+    #[inline]
+    pub(super) fn delete_self(&self) -> bool {
+        delete_entry(&self.next, Relaxed)
+    }
+
+    #[inline]
+    pub(super) fn is_deleted(&self) -> bool {
+        is_deleted_entry(&self.next, Relaxed)
+    }
+
+    #[inline]
+    pub(super) fn next_ptr<'g>(&self, guard: &'g Guard) -> Ptr<'g, Self> {
+        next_entry(&self.next, &|l| &l.next, 32, Acquire, guard)
     }
 
     /// Extracts the inner instance of `T`.
@@ -387,7 +343,7 @@ impl<T: Debug> Debug for Entry<T> {
         f.debug_struct("Entry")
             .field("instance", &self.instance)
             .field("next", &self.next)
-            .field("removed", &self.is_deleted(Relaxed))
+            .field("removed", &self.is_deleted())
             .finish()
     }
 }
@@ -412,7 +368,7 @@ impl<T> Drop for Entry<T> {
     #[inline]
     fn drop(&mut self) {
         if !self.next.is_null(Relaxed) {
-            self.next_ptr(Relaxed, &Guard::new());
+            self.next_ptr(&Guard::new());
         }
     }
 }
@@ -430,16 +386,122 @@ impl<T: Display> Display for Entry<T> {
 
 impl<T: Eq> Eq for Entry<T> {}
 
-impl<T> LinkedList for Entry<T> {
-    #[inline]
-    fn link_ref(&self) -> &AtomicShared<Self> {
-        &self.next
-    }
-}
-
 impl<T: PartialEq> PartialEq for Entry<T> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.instance == other.instance
     }
+}
+
+/// Returns `true` if `current` is reachable and not marked.
+fn is_clear_entry<T>(current: &AtomicShared<T>, order: Ordering) -> bool {
+    current.tag(order) == Tag::None
+}
+
+/// Marks `current` with an internal flag to denote that `current` is in a user-defined state.
+fn mark_entry<T>(current: &AtomicShared<T>, order: Ordering) -> bool {
+    current.update_tag_if(Tag::First, |ptr| ptr.tag() == Tag::None, order, Relaxed)
+}
+
+/// Removes any mark from `current`.
+fn unmark_entry<T>(current: &AtomicShared<T>, order: Ordering) -> bool {
+    current.update_tag_if(Tag::None, |ptr| ptr.tag() == Tag::First, order, Relaxed)
+}
+
+/// Returns `true` if `current` has a mark on it.
+fn is_marked_entry<T>(current: &AtomicShared<T>, order: Ordering) -> bool {
+    current.tag(order) == Tag::First
+}
+
+/// Deletes `current` from the linked list.
+fn delete_entry<T>(current: &AtomicShared<T>, order: Ordering) -> bool {
+    current.update_tag_if(Tag::Second, |ptr| ptr.tag() != Tag::Second, order, Relaxed)
+}
+
+/// Checks if `current` has been deleted from the linked list.
+fn is_deleted_entry<T>(current: &AtomicShared<T>, order: Ordering) -> bool {
+    current.tag(order) == Tag::Second
+}
+
+/// Appends the given entry to `current` and returns a pointer to the entry.
+fn push_back_entry<'g, T, F: Fn(&T) -> &AtomicShared<T>>(
+    current: &AtomicShared<T>,
+    mut entry: Shared<T>,
+    mark: bool,
+    next_getter: F,
+    order: Ordering,
+    guard: &'g Guard,
+) -> Result<Ptr<'g, T>, Shared<T>> {
+    let new_tag = if mark { Tag::First } else { Tag::None };
+    let mut next_ptr = current.load(Relaxed, guard);
+    while next_ptr.tag() != Tag::Second {
+        next_getter(&*entry).swap((next_ptr.get_shared(), Tag::None), Relaxed);
+        match current.compare_exchange_weak(next_ptr, (Some(entry), new_tag), order, Relaxed, guard)
+        {
+            Ok((_, updated)) => {
+                return Ok(updated);
+            }
+            Err((passed, actual)) => {
+                entry = unsafe { passed.unwrap_unchecked() };
+                next_ptr = actual;
+            }
+        }
+    }
+
+    // `current` has been deleted.
+    Err(entry)
+}
+
+/// Returns the closest next valid [`Ptr`] reachable from `current`.
+///
+/// This removes any invalid entry between `current` and the returned [`Ptr`].
+fn next_entry<'g, T, F: Fn(&T) -> &AtomicShared<T>>(
+    current: &AtomicShared<T>,
+    next_getter: &F,
+    depth: usize,
+    order: Ordering,
+    guard: &'g Guard,
+) -> Ptr<'g, T> {
+    let self_next_ptr = current.load(order, guard);
+    let mut next_ptr = self_next_ptr;
+    let next_valid_ptr = loop {
+        if let Some(next_ref) = next_ptr.as_ref() {
+            let next_next_ptr = next_getter(next_ref).load(order, guard);
+            if next_next_ptr.tag() == Tag::None || next_next_ptr.tag() == Tag::First {
+                break next_ptr;
+            }
+            if depth == 0 {
+                next_ptr = next_next_ptr;
+            } else {
+                // This makes recursive calls.
+                //
+                // The stack size is 32-byte - `current`, `depth`, and `self_next_ptr`, therefore a
+                // recursive call of a depth of 32 requires 1KB stack size.
+                break next_entry(next_getter(next_ref), next_getter, depth - 1, order, guard);
+            }
+        } else {
+            break Ptr::null();
+        }
+    };
+
+    // Update its link if an invalid entry has been found.
+    if self_next_ptr != next_valid_ptr {
+        // Need to check the validity of the `Shared` otherwise the linked list can be broken.
+        let next_valid_entry = next_valid_ptr.get_shared();
+        if next_valid_ptr.is_null() == next_valid_entry.is_none() {
+            // Keep the tag value.
+            current
+                .compare_exchange(
+                    self_next_ptr,
+                    (next_valid_entry, self_next_ptr.tag()),
+                    Release,
+                    Relaxed,
+                    guard,
+                )
+                .ok()
+                .map(|(p, _)| p.map(|p| p.release(guard)));
+        }
+    }
+
+    next_valid_ptr
 }

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -8,7 +8,8 @@ pub trait LinkedList: Sized {
     /// Returns a reference to the forward link.
     ///
     /// The pointer value may be tagged if [`Self::mark`] or [`Self::delete_self`] has been
-    /// invoked.
+    /// invoked. The [`AtomicShared`] must only be updated through [`LinkedList`] in order to keep
+    /// the linked list consistent.
     fn link_ref(&self) -> &AtomicShared<Self>;
 
     /// Returns `true` if `self` is reachable and not marked.

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -420,10 +420,7 @@ impl<T> Stack<T> {
             if newest_entry.is_deleted() {
                 match self.newest.compare_exchange(
                     newest_ptr,
-                    (
-                        newest_entry.next_ptr(guard).get_shared(),
-                        Tag::None,
-                    ),
+                    (newest_entry.next_ptr(guard).get_shared(), Tag::None),
                     AcqRel,
                     Acquire,
                     guard,

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,7 +1,7 @@
 //! [`Stack`] is a lock-free concurrent last-in-first-out container.
 
 use super::ebr::{AtomicShared, Guard, Ptr, Shared, Tag};
-use super::linked_list::{Entry, LinkedList};
+use super::linked_list::Entry;
 use std::fmt::{self, Debug};
 use std::iter::FusedIterator;
 use std::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed};
@@ -255,10 +255,10 @@ impl<T> Stack<T> {
         let mut newest_ptr = self.cleanup_newest(self.newest.load(Acquire, &guard), &guard);
         while !newest_ptr.is_null() {
             if let Some(newest_entry) = newest_ptr.get_shared() {
-                if !newest_entry.is_deleted(Relaxed) && !cond(&*newest_entry) {
+                if !newest_entry.is_deleted() && !cond(&*newest_entry) {
                     return Err(newest_entry);
                 }
-                if newest_entry.delete_self(Relaxed) {
+                if newest_entry.delete_self() {
                     self.cleanup_newest(newest_ptr, &guard);
                     return Ok(Some(newest_entry));
                 }
@@ -417,11 +417,11 @@ impl<T> Stack<T> {
         guard: &'g Guard,
     ) -> Ptr<'g, Entry<T>> {
         while let Some(newest_entry) = newest_ptr.as_ref() {
-            if newest_entry.is_deleted(Relaxed) {
+            if newest_entry.is_deleted() {
                 match self.newest.compare_exchange(
                     newest_ptr,
                     (
-                        newest_entry.next_ptr(Acquire, guard).get_shared(),
+                        newest_entry.next_ptr(guard).get_shared(),
                         Tag::None,
                     ),
                     AcqRel,
@@ -457,7 +457,7 @@ impl<T: Clone> Clone for Stack<T> {
                     .swap((Some(new_entry.clone()), Tag::None), Relaxed);
             }
             oldest.replace(new_entry);
-            current = entry.next_ptr(Acquire, &guard);
+            current = entry.next_ptr(&guard);
         }
         self_clone
     }
@@ -470,7 +470,7 @@ impl<T: Debug> Debug for Stack<T> {
         let guard = Guard::new();
         let mut current = self.newest.load(Acquire, &guard);
         while let Some(entry) = current.as_ref() {
-            let next = entry.next_ptr(Acquire, &guard);
+            let next = entry.next_ptr(&guard);
             d.entry(entry);
             current = next;
         }
@@ -495,7 +495,7 @@ impl<'g, T> Iterator for Iter<'g, T> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(current) = self.current.as_ref() {
-            self.current = current.next_ptr(Acquire, self.guard);
+            self.current = current.next_ptr(self.guard);
             Some(current)
         } else {
             None

--- a/src/tests/correctness.rs
+++ b/src/tests/correctness.rs
@@ -2522,8 +2522,8 @@ mod queue_test {
 
                         barrier_clone.wait().await;
                         let guard = Guard::new();
-                        let mut iter = queue_clone.iter(&guard);
-                        while let Some(current) = iter.next() {
+                        let iter = queue_clone.iter(&guard);
+                        for current in iter {
                             let current = current.1;
                             assert!(current == 0 || last + 1 == current);
                             last = current;
@@ -2658,8 +2658,8 @@ mod stack_test {
 
                         barrier_clone.wait().await;
                         let guard = Guard::new();
-                        let mut iter = stack_clone.iter(&guard);
-                        while let Some(current) = iter.next() {
+                        let iter = stack_clone.iter(&guard);
+                        for current in iter {
                             let current = current.1;
                             assert!(last == workload_size || last - 1 == current);
                             last = current;


### PR DESCRIPTION
`Entry` no longer exposes `LinkedList` API.
Make it clear that `HashCache` is a 32-way associative cache.