### PR TITLE
chore(doc): replace `edr` references by `sdd` in the docs

### DIFF
--- a/src/hash_map.rs
+++ b/src/hash_map.rs
@@ -43,7 +43,7 @@ use std::sync::atomic::Ordering::{Acquire, Relaxed};
 ///
 /// ### Bucket access
 ///
-/// Bucket arrays are protected by [`ebr`](super::ebr), thus allowing lock-free access to them.
+/// Bucket arrays are protected by [`sdd`], thus allowing lock-free access to them.
 ///
 /// ### Entry access
 ///

--- a/src/wait_queue.rs
+++ b/src/wait_queue.rs
@@ -15,7 +15,7 @@ const ASYNC: usize = 1_usize;
 /// [`WaitQueue`] implements an unfair wait queue.
 ///
 /// The sole purpose of the data structure is to avoid busy-waiting. [`WaitQueue`] should always
-/// protected by [`ebr`](crate::ebr).
+/// protected by [`sdd`].
 #[derive(Debug, Default)]
 pub(crate) struct WaitQueue {
     /// Stores the pointer value of the actual wait queue entry and a flag indicating that the


### PR DESCRIPTION
This can be quite confusing for new users and these seem to be the last two references in the public documentation.