### PR TITLE
chore(hash*): enhance load factor sampling

### DIFF
--- a/src/hash_table/bucket_array.rs
+++ b/src/hash_table/bucket_array.rs
@@ -143,13 +143,6 @@ impl<K, V, L: LruList, const TYPE: char> BucketArray<K, V, L, TYPE> {
         self.sample_size as usize
     }
 
-    /// Returns the recommended full sampling size.
-    #[inline]
-    pub(crate) const fn full_sample_size(&self) -> usize {
-        // `Log2(array_len) * 2`: if `array_len` is sufficiently large, expected error is `~2%`.
-        self.sample_size() * 2
-    }
-
     /// Returns a reference to a [`Bucket`] at the given position.
     #[inline]
     pub(crate) const fn bucket(&self, index: usize) -> &Bucket<K, V, L, TYPE> {


### PR DESCRIPTION
this ameliorates a situation where the size estimation goes wrong when `retain` bulk-deletes entries from the beginning of the table while a thread is inserting keys at the end of the table.